### PR TITLE
Fixes context for notFound in `NpmProxy.decide`

### DIFF
--- a/lib/npm-proxy.js
+++ b/lib/npm-proxy.js
@@ -185,7 +185,6 @@ NpmProxy.prototype.decide = function (req, res, policy) {
       method   = req.method.toLowerCase(),
       pkg      = url.slice(1).split('/').shift(),
       proxy    = this.proxy,
-      notFound = this.notFound,
       self     = this,
       decideFn;
 
@@ -199,7 +198,7 @@ NpmProxy.prototype.decide = function (req, res, policy) {
     // potential whitelist.
     //
     if (err || !target) {
-      return notFound(req, res, err || { message: 'Unknown pkg: ' + pkg });
+      return self.notFound(req, res, err || { message: 'Unknown pkg: ' + pkg });
     }
     //
     // If we get a valid target then we can proxy to it


### PR DESCRIPTION
If you were to enable whitelist and you try to install a package that is
not in the whitelist, an error is thrown when `this.log` is called in
`lib/npm-proxy.js` on line 244.  By referencing `this.notFound` on line
188, we lose `this` in `NpmProxy.notFound`
