### PR TITLE
Fixes issue #3

### DIFF
--- a/lib/npm-proxy.js
+++ b/lib/npm-proxy.js
@@ -6,7 +6,8 @@
  */
 
 var httpProxy = require('http-proxy'),
-    request = require('request').defaults({ strictSSL: false });
+    request = require('request').defaults({ strictSSL: false }),
+    url_ = require('url');
 
 //
 // ### function NpmProxy (options)
@@ -465,7 +466,7 @@ NpmProxy.prototype.merge = function (req, res, policy) {
 
     self.log('[merge] %s - %s %s %s %j', address, req.method, req.url, target.host, req.headers);
     return request({
-      url:     target.href + url,
+      url:     url_.resolve(target.href, url),
       method:  method,
       headers: headers
     });


### PR DESCRIPTION
Since policy.npm is `url.parse`d, the href property it returns will have
an ending slash.  Some hosts cannot handle an additional slash in the
middle of a url.
