### PR TITLE
Fixes #5

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -51,7 +51,7 @@ exports.createServer = function (options, callback) {
 //
 exports.createRouter = function createRouter(options, callback) {
   var router = new director.http.Router(),
-      log    = options.log || console.log,
+      log    = options.log || console,
       proxy  = options.proxy,
       rewrites,
       server;
@@ -116,7 +116,7 @@ exports.createRouter = function createRouter(options, callback) {
           ? new RegExp(rr.from.replace(wc, '.*'))
           : rr.from;
 
-    log('[route] %s - %s %s', 'merge', method, rr.from);
+    log.info('[route]', '%s - %s %s', 'merge', method, rr.from);
     router[method](from, function () {
       proxy.merge(this.req, this.res);
     });
@@ -133,7 +133,7 @@ exports.createRouter = function createRouter(options, callback) {
     var method = rr.method.toLowerCase(),
         from   = rr.from;
 
-    log('[route] %s - %s %s', 'public', method, from);
+    log.info('[route]', '%s - %s %s', 'public', method, from);
     router[method](from, function () {
       proxy.public(this.req, this.res);
     });
@@ -147,7 +147,7 @@ exports.createRouter = function createRouter(options, callback) {
     ['GET', 'PUT', 'DELETE'].forEach(function (method) {
       method = method.toLowerCase();
 
-      log('[route] %s - %s %s', 'decide', method, re.source);
+      log.info('[route]', '%s - %s %s', 'decide', method, re.source);
       router[method](re, function () {
         proxy.decide(this.req, this.res);
       });

--- a/lib/npm-proxy.js
+++ b/lib/npm-proxy.js
@@ -20,7 +20,7 @@ var httpProxy = require('http-proxy'),
 // ####     - blacklist   {Object}    Set of initial blacklisted modules.
 // ####     - whitelist   {Object}    Set of iniitial whitelisted modules.
 // ####   @writePrivateOk {function}  **Optional** Predicate for writing new private packages.
-// ####   @log            {function}  **Optional** Log function. Defaults to console.log.
+// ####   @log            {function}  **Optional** Log function. Defaults to console.
 //
 // Constructor function for the NpmProxy object responsible for
 // making proxy decisions between multiple npm registries.
@@ -32,7 +32,7 @@ var NpmProxy = module.exports = function (options) {
   // URL to CouchDB and the proxy instance to use.
   //
   this.npm = options.npm;
-  this.log = options.log || console.log;
+  this.log = options.log || console;
 
   //
   // Setup the http-proxy instance to handle bad respones
@@ -103,7 +103,7 @@ NpmProxy.prototype.nextPublicNpm = function () {
       lastNpm = this.currentNpm;
 
   this.currentNpm = this.npm.splice(index, 1)[0];
-  this.log('[public npm] %s --> %s', (lastNpm && lastNpm.href) || 'none', this.currentNpm.href);
+  this.log.info('[public npm]', '%s --> %s', (lastNpm && lastNpm.href) || 'none', this.currentNpm.href);
   if (lastNpm) {
     this.npm.push(lastNpm);
   }
@@ -119,7 +119,7 @@ NpmProxy.prototype.nextPublicNpm = function () {
 //
 NpmProxy.prototype.public = function (req, res) {
   var address = req.connection.remoteAddress || req.socket.remoteAddress;
-  this.log('[public] %s - %s %s %s %j', address, req.method, req.url, this.currentNpm.vhost, req.headers);
+  this.log.info('[public]', '%s - %s %s %s %j', address, req.method, req.url, this.currentNpm.vhost, req.headers);
   req.headers.host = this.currentNpm.vhost;
 
   this.proxy.web(req, res, {
@@ -147,7 +147,7 @@ NpmProxy.prototype.private = function (req, res, policy) {
   }
 
   var address = req.connection.remoteAddress || req.socket.remoteAddress;
-  this.log('[private] %s - %s %s %s %j', address, req.method, req.url, policy.npm.vhost, req.headers);
+  this.log.info('[private]', '%s - %s %s %s %j', address, req.method, req.url, policy.npm.vhost, req.headers);
   req.headers.host = policy.npm.vhost;
 
   this.proxy.web(req, res, {
@@ -205,7 +205,7 @@ NpmProxy.prototype.decide = function (req, res, policy) {
     //
     // If we get a valid target then we can proxy to it
     //
-    self.log('[decide] %s - %s %s %s %j', address, req.method, req.url, target.vhost, req.headers);
+    self.log.info('[decide]', '%s - %s %s %s %j', address, req.method, req.url, target.vhost, req.headers);
     req.headers.host = target.vhost;
     proxy.web(req, res, {
       target: target.href
@@ -243,7 +243,7 @@ NpmProxy.prototype.notFound = function (req, res, err) {
 
   if (!err) { global.console.trace(); }
   err = err || { message: 'Unknown error' };
-  this.log('[not found] %s - %s %s %s %j', address, req.method, req.url, err.message, req.headers);
+  this.log.error('[not found]', '%s - %s %s %s %j', address, req.method, req.url, err.message, req.headers);
 
   res.writeHead(code, { 'content-type': 'text/plain' });
   res.end(err.message);
@@ -464,7 +464,7 @@ NpmProxy.prototype.merge = function (req, res, policy) {
     //
     headers.host = target.host;
 
-    self.log('[merge] %s - %s %s %s %j', address, req.method, req.url, target.host, req.headers);
+    self.log.info('[merge]', '%s - %s %s %s %j', address, req.method, req.url, target.host, req.headers);
     return request({
       url:     url_.resolve(target.href, url),
       method:  method,
@@ -535,7 +535,7 @@ NpmProxy.prototype.onProxyError = function (err, req, res) {
   var address = req.connection.remoteAddress || req.socket.remoteAddress,
       code    = res.statusCode || 500;
 
-  this.log('[proxy error] %s - %s %s %s %j', address, req.method, req.url, err.message, req.headers);
+  this.log.error('[proxy error]', '%s - %s %s %s %j', address, req.method, req.url, err.message, req.headers);
   res.writeHead(code, { 'content-type': 'text/plain' });
   res.end('npm proxy error: ' + err.message);
 };


### PR DESCRIPTION
Allows for better logging.

Allow for a compatible logger to be passed as options.log.  Otherwise,
defaults to `console`.  A compatible logger would have both `error` and
`info` methods.
