### PR TITLE
[fix] Account for changes in npm-registry-client

### DIFF
--- a/lib/npm-proxy.js
+++ b/lib/npm-proxy.js
@@ -205,7 +205,7 @@ NpmProxy.prototype.decide = function (req, res, policy) {
   var address  = req.connection.remoteAddress || req.socket.remoteAddress,
       url      = req.url,
       method   = req.method.toLowerCase(),
-      pkg      = url.slice(1).split('/').shift(),
+      pkg      = url.slice(1).split('?').shift().split('/').shift(),
       proxy    = this.proxy,
       self     = this,
       decideFn;


### PR DESCRIPTION
When publishing, npm now makes a GET request to `/:pkg?write=true`
This prevents the `pkg` from including the querystring when checking
whether it exists in policy.{private,blacklist,whitelist}

The change to npm-registry-client can be found at https://github.com/npm/npm-registry-client/blob/master/lib/publish.js#L98
