### PR TITLE
[fix] X-Forwarded-Host header is incompatible with npm

### DIFF
--- a/lib/npm-proxy.js
+++ b/lib/npm-proxy.js
@@ -249,6 +249,10 @@ NpmProxy.prototype.decide = function (req, res, policy) {
     if (err || !target) {
       return self.notFound(req, res, err || { message: 'Unknown pkg: ' + pkg });
     }
+
+    // if X-Forwarded-Host is set, npm returns 404 {"error":"not_found","reason":"no_db_file"}
+    if (req.headers["x-forwarded-host"]) delete req.headers["x-forwarded-host"];
+
     //
     // If we get a valid target then we can proxy to it
     //


### PR DESCRIPTION
Hello,

I discovered that when `X-Forwarded-Host` header is set, **npm** responds with a `404`, and:

``` json
{"error":"not_found","reason":"no_db_file"}
```

 This issue can be replicated with `curl` and any value for `X-Forwarded-Host`:

``` sh
curl -H "X-Forwarded-Host: google.com" https://registry.npmjs.org/underscore
```

I guess the proxy setup used at npm is confused by the header.  The proxy on OpenShift that forwards to my **smart-private-npm** instance sets the header.  Removing the header before creating the **http-proxy** solves the issue.

I have tested with all `X-Forwarded-*` and other headers set by OpenShift proxy, and none cause any issue.
