### PR TITLE
[fix] update http-proxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "create-servers": "~1.2.0",
     "director": "~1.2.2",
-    "http-proxy": "1.4.x",
+    "http-proxy": "^1.11.1",
     "minimist": "1.x",
     "npm-registry-packages": "1.x",
     "request": "~2.33.0",


### PR DESCRIPTION
When installing `smart-private-npm`, I got an error with http-proxy:
```
util.js:728
    throw new TypeError('The super constructor to `inherits` must not ' +
          ^
TypeError: The super constructor to `inherits` must not be null or undefined.
    at Object.exports.inherits (util.js:728:11)
    at Object.<anonymous> (./node_modules/http-proxy/lib/http-proxy/index.js:111:17)
    at Module._compile (module.js:426:26)
    at Object.Module._extensions..js (module.js:444:10)
    at Module.load (module.js:351:32)
    at Function.Module._load (module.js:306:12)
    at Module.require (module.js:361:17)
    at require (module.js:380:17)
    at Object.<anonymous> (./node_modules/http-proxy/lib/http-proxy.js:4:17)
    at Module._compile (module.js:426:26)
```

Updating to 1.11.1 solves the problem.

- node: iojs-v2.2.1
- smart-private-npm: 2.0.0
