### PR TITLE
Pass along the target information when emitting the `"headers"` event.

### DIFF
--- a/lib/npm-proxy.js
+++ b/lib/npm-proxy.js
@@ -162,7 +162,7 @@ NpmProxy.prototype.public = function (req, res) {
 
   this.log.info('[public] %s - %s %s %s %j', address, req.method, req.url, host, req.headers);
 
-  this.emit('headers', req, req.headers);
+  this.emit('headers', req, req.headers, npm);
 
   req.headers.host = host;
 
@@ -195,7 +195,7 @@ NpmProxy.prototype.private = function (req, res, policy) {
 
   this.log.info('[private] %s - %s %s %s %j', address, req.method, req.url, host, req.headers);
 
-  this.emit('headers', req, req.headers);
+  this.emit('headers', req, req.headers, policy.npm);
 
   req.headers.host = host;
 
@@ -259,7 +259,7 @@ NpmProxy.prototype.decide = function (req, res, policy) {
     //
     self.log.info('[decide] %s - %s %s %s %j', address, req.method, req.url, target.vhost || target.host || target.hostname, req.headers);
 
-    self.emit('headers', req, req.headers);
+    self.emit('headers', req, req.headers, target);
 
     req.headers.host = target.vhost || target.host || target.hostname;
     proxy.web(req, res, {


### PR DESCRIPTION
Needed because reasons.