### PR TITLE
[bin] unify configuration; getPkgs available programmatically

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -1,4 +1,9 @@
 //
+// Default rewrites for routes
+//
+exports.rewrites = require('./rewrites');
+
+//
 // Default CouchDB documents to exclude
 //
 exports.exclude = [
@@ -9,15 +14,18 @@ exports.exclude = [
   'error: forbidden',
 ];
 
-//
-// Private npm registry url
-//
-exports.private = 'http://localhost:5984';
-
-//
-// Public npm registry url
-//
-exports.public = 'https://registry.nodejitsu.com';
+exports.proxy = {
+  //
+  // Public npm registry url
+  //
+  npm: 'https://registry.nodejitsu.com',
+  policy: {
+    //
+    // Private npm registry url
+    //
+    npm: 'http://localhost:5984'
+  }
+};
 
 //
 // Function to filter excluded documents

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,8 @@
  */
 
 var createServers = require('create-servers'),
-    director = require('director');
+    director = require('director'),
+    getPkgs = require('npm-registry-packages');
 
 var patterns = {
   packageAnd:  /\/([_\.\(\)!\\ %@&a-zA-Z0-9-]+)\/.*/,
@@ -177,4 +178,53 @@ exports.createRouter = function createRouter(options, callback) {
 
   router.proxy = proxy;
   return router;
+};
+
+//
+// ### function getPkgs (options, callback)
+// #### @options {Object} Options for starting the proxy
+// ####   - log      {function} Logging function to use.
+// ####   - exclude  {Array}    Default CouchDB documents to exclude.
+// ####   - filter   {function} Filter function for CouchDB documente exclusion.
+// ####   - ip       {boolean}  Whether to ignore packages from private registry.
+//
+exports.getPkgs = function(config, cb) {
+  url = config.private || config.proxy.policy.npm;
+  if (url.href) url = url.href;
+
+  getPkgs(url, function(err, pkgs) {
+    if (err) {
+      return cb(err);
+    }
+
+    if (!config.filter) {
+      pkgs = pkgs.filter(function(f) {
+        return (!(~config.exclude.indexOf(f)));
+      });
+    }
+
+    var privatePkgs = {},
+        len = pkgs.length,
+        log = config.log;
+
+    if (!config.ip) {
+      for (var i=0; i<len; i++) {
+        var pkg = pkgs[i];
+        privatePkgs[pkg] = 1;
+      }
+
+      config.exclude.forEach(function(e) {
+        log.info('[getPkgs] excluding package: '+e);
+        if (privatePkgs.hasOwnProperty(e)) {
+          delete privatePkgs[e];
+        }
+      });
+
+      log.info('[getPkgs] loaded private packages', privatePkgs);
+    } else {
+      log.info('[getPkgs] ignoring packages from private registry');
+    }
+
+    cb(null, privatePkgs);
+  });
 };


### PR DESCRIPTION
These changes simplify the configuration defaults and add the ability to customize how packages are loaded.  I have been using it for months, to load my list of private packages from the Cloudant DB in which they reside.  This should make it easier for anyone to get started quickly, regardless of the backing store.
